### PR TITLE
Read clang-format binary command from env variable with default

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 A basic clang-format Rust wrapper.
 
 This allows for formatting a given input using `clang-format` from the system.
+By default it uses `clang-format` binary but this can be changed by setting the
+`CLANG_FORMAT_BINARY` environment variable, for example,
+`CLANG_FORMAT_BINARY=clang-format-16`
 
 ```rust
 use clang_format::{clang_format, ClangFormatStyle, CLANG_FORMAT_STYLE};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use once_cell::sync::OnceCell;
+use std::env;
 use std::io::Write;
 use std::process::{Command, Stdio};
 
@@ -66,7 +67,8 @@ fn clang_format_with_style(
     style: &ClangFormatStyle,
 ) -> Result<String, ClangFormatError> {
     // Create and try to spawn the command with the specified style
-    if let Ok(mut child) = Command::new("clang-format")
+    let clang_binary = env::var("CLANG_FORMAT_BINARY").unwrap_or("clang-format".to_string());
+    if let Ok(mut child) = Command::new(clang_binary.as_str())
         .arg(format!("--style={}", style.as_str()))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())


### PR DESCRIPTION
Hey Team!

Thanks for the helpful package. Proposing a minor change.

**Context**
This package uses `clang-format` as the binary but many systems need to run different versions of the `clang-format` binary in the same environment. This is usually achieved by having version number part of the binary like `clang-format-16`.

**Outcome**
This PR introduces a new environment variable - `CLANG_FORMAT_BINARY` - to allow selecting the specific binary at runtime and defaults to `clang-format` when not provided thereby maintaining backward compatibility. 