### PR TITLE
clang-format: mark ClangFormatStyle as non_exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `GNU` as a clang-format style
 - Support for `Microsoft` as a clang-format style
 
+### Changed
+
+- `ClangFormatStyle` enum is now marked as `non_exhaustive` to allow for more styles in the future
+
 ## [0.2.0](https://github.com/KDAB/clang-format-rs/compare/v0.1.3...v0.2.0) - 2023-08-02
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ use std::process::{Command, Stdio};
 /// This list is created from
 /// <https://clang.llvm.org/docs/ClangFormatStyleOptions.html#basedonstyle>
 #[derive(Debug, PartialEq)]
+#[non_exhaustive]
 pub enum ClangFormatStyle {
     /// A style complying with [Chromium’s style guide](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/styleguide/styleguide.md)
     Chromium,


### PR DESCRIPTION
This allows for more styles to be added in the future.